### PR TITLE
Bug fixes/archive divider overlapping

### DIFF
--- a/src/components/directs/list/ArchivedDirectCount.js
+++ b/src/components/directs/list/ArchivedDirectCount.js
@@ -28,6 +28,7 @@ function ArchivedDirectCount({ count }) {
   return (
     <List>
       <ListItem
+        style={{ zIndex: 0 }}
         primaryText={`Archived : ( ${count} )`}
         containerElement={<Link to={{ pathname: '/directs/archived', state: { isArchived: true } }} />}
       />

--- a/src/components/directs/list/item/DirectItem.jsx
+++ b/src/components/directs/list/item/DirectItem.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router';
 import { ListItem } from 'material-ui/List';
 import Avatar from 'material-ui/Avatar';
 import { grey400, grey900 } from 'material-ui/styles/colors';

--- a/src/components/directs/single/DirectSingle.js
+++ b/src/components/directs/single/DirectSingle.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router';
 import {
   Card,
   CardTitle,


### PR DESCRIPTION
1.Set z-index of the direct list item to 0.
This bug is same as on Direct List Items. Looks like material-ui has a problem with z-index on ListItem component

2. Removed unused Link component from files