### PR TITLE
localStorge for directs sortBy

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "redux-form-material-ui": "^4.1.2",
     "redux-thunk": "^2.1.0",
     "reselect": "^3.0.1",
+    "store": "^2.0.12",
     "tinycolor2": "^1.4.1",
     "validator": "^7.0.0"
   },

--- a/src/actions/directs.js
+++ b/src/actions/directs.js
@@ -1,11 +1,15 @@
+import locStore from 'store';
 import * as types from './types';
 import { FirebaseApi } from '../firebase/firebase';
-import { ARCHIVED_PATH_PREFIX } from '../constants/general';
+import { ARCHIVED_PATH_PREFIX, SORT_BY_KEY_NAME } from '../constants/general';
 
 export const setSortBy = (value) => {
-  return {
-    type: types.SET_DIRECTS_SORT_BY,
-    payload: value,
+  return (dispatch) => {
+    locStore.set(SORT_BY_KEY_NAME,value);
+    dispatch({
+      type: types.SET_DIRECTS_SORT_BY,
+      payload: value,
+    });
   };
 };
 
@@ -16,7 +20,7 @@ export const archivedDirects = new FirebaseApi(`${ARCHIVED_PATH_PREFIX}directs`,
   RESET_ACTIVE: types.ARCHIVED_RESET_ACTIVE_DIRECT,
   CREATE: types.ARCHIVED_CREATE_DIRECT,
   SET_MATCHING: types.ARCHIVED_SET_MATCHING_DIRECTS,
-},'name');
+}, 'name');
 
 export default new FirebaseApi('directs', {
   LOAD_SUCCESS: types.LOAD_DIRECTS_SUCCESS,
@@ -25,4 +29,4 @@ export default new FirebaseApi('directs', {
   RESET_ACTIVE: types.RESET_ACTIVE_DIRECT,
   CREATE: types.CREATE_DIRECT,
   SET_MATCHING: types.SET_MATCHING_DIRECTS,
-},'name');
+}, 'name');

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -8,7 +8,7 @@ import { browserHistory } from 'react-router';
 import Header from './Header';
 import LeftDrawer from './LeftDrawer';
 import BottomNav from './BottomNav';
-import store from '../store';
+import store from '../store/store';
 import { listenToAuth } from '../actions/auth';
 
 const muiTheme = getMuiTheme({

--- a/src/constants/general.js
+++ b/src/constants/general.js
@@ -1,4 +1,11 @@
 /**
+ * @description Sort by key name. Used for local storage
+ * @const {string}
+ * @default
+ */
+export const SORT_BY_KEY_NAME = 'directsSortBy';
+
+/**
  * @description Sort by name constant
  * @const {string}
  * @default

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import injectTapEventPlugin from 'react-tap-event-plugin';
 import { Provider } from 'react-redux';
 import ReactGA from 'react-ga';
 
-import store, { history } from './store';
+import store, { history } from './store/store';
 import './index.css';
 import routes from './routes';
 

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -7,15 +7,7 @@ import {
   AUTH_LOGIN,
   AUTH_OPEN } from '../actions/types';
 
-const INITIAL_STATE = {
-  displayName: null,
-  uid: null,
-  email: null,
-  photoURL: null,
-  status: AUTH_ANONYMOUS,
-};
-
-export default (state = INITIAL_STATE, action) => {
+export default (state = {}, action) => {
   switch (action.type) {
     case AUTH_OPEN:
       return {

--- a/src/reducers/directs.js
+++ b/src/reducers/directs.js
@@ -1,18 +1,7 @@
 import * as types from '../actions/types';
-import { SORT_BY_NAME } from '../constants/general';
 
-const INITIAL_STATE = {
-  activeDirect: null,
-  list: [],
-  loading: false,
-  error: null,
-  sortBy: SORT_BY_NAME,
-};
-
-
-export default function (name='') {
-
-  return function (state = INITIAL_STATE, action) {
+export default function (name = '') {
+  return function (state = {}, action) {
     switch (action.type) {
       case name + types.LOAD_DIRECTS_SUCCESS:
         return {
@@ -20,7 +9,7 @@ export default function (name='') {
           list: action.payload,
         };
       case name + types.UNLOAD_DIRECTS_SUCCESS:
-        return INITIAL_STATE;
+        return state;
       case name + types.SET_ACTIVE_DIRECT:
         return {
           ...state,

--- a/src/reducers/followUps.js
+++ b/src/reducers/followUps.js
@@ -1,14 +1,7 @@
 import * as types from '../actions/types';
 
-const INITIAL_STATE = {
-  list: {},
-  activeFollowUp: null,
-  activeFollowUpKey: null,
-  loading: false,
-  error: null,
-};
 export default function (name = '') {
-  return function (state = INITIAL_STATE, action) {
+  return function (state = {}, action) {
     switch (action.type) {
       case name + types.LOAD_FOLLOW_UPS_SUCCESS:
         return { ...state,
@@ -17,7 +10,7 @@ export default function (name = '') {
         return { ...state,
           matchingList: action.payload };
       case name + types.UNLOAD_FOLLOW_UPS_SUCCESS:
-        return INITIAL_STATE;
+        return state;
       case name + types.SET_ACTIVE_FOLLOW_UP:
         return { ...state,
           activeFollowUp: action.payload,

--- a/src/reducers/header.js
+++ b/src/reducers/header.js
@@ -1,17 +1,13 @@
 import * as types from '../actions/types';
 
-const INITIAL_STATE = {
-  text: '1on1 Tracker',
-};
-
-export default function (state = INITIAL_STATE, action) {
+export default function (state = {}, action) {
   switch (action.type) {
     case types.HEADER_SET_TEXT:
       return { ...state,
         text: action.payload,
       };
     case types.HEADER_RESET:
-      return INITIAL_STATE;
+      return state;
     default:
       return state;
   }

--- a/src/reducers/meetings.js
+++ b/src/reducers/meetings.js
@@ -1,20 +1,13 @@
 import * as types from '../actions/types';
 
-const INITIAL_STATE = {
-  list: {},
-  activeMeeting: null,
-  activeMeetingKey: null,
-  loading: false,
-  error: null,
-};
 export default function (name = '') {
-  return function (state = INITIAL_STATE, action) {
+  return function (state = {}, action) {
     switch (action.type) {
       case name + types.LOAD_MEETINGS_SUCCESS:
         return { ...state,
           list: action.payload };
       case name + types.UNLOAD_MEETINGS_SUCCESS:
-        return INITIAL_STATE;
+        return state;
       case name + types.SET_ACTIVE_MEETING:
         return { ...state,
           activeMeeting: action.payload,

--- a/src/reducers/teams.js
+++ b/src/reducers/teams.js
@@ -1,12 +1,6 @@
 import * as types from '../actions/types';
 
-const INITIAL_STATE = {
-  list: {},
-  loading: false,
-  error: null,
-};
-
-export default function (state = INITIAL_STATE, action) {
+export default function (state = {}, action) {
   switch (action.type) {
     case types.LOAD_TEAMS_SUCCESS:
       return {
@@ -16,7 +10,7 @@ export default function (state = INITIAL_STATE, action) {
     case types.UNLOAD_TEAMS_SUCCESS:
       return {
         ...{},
-        ...INITIAL_STATE,
+        ...state,
       };
     default:
       return state;

--- a/src/store/initialState.js
+++ b/src/store/initialState.js
@@ -1,0 +1,65 @@
+import locStore from 'store';
+import { SORT_BY_NAME, SORT_BY_KEY_NAME } from '../constants/general';
+import { AUTH_ANONYMOUS } from '../actions/types';
+
+const initialState = {
+  directs: {
+    activeDirect: null,
+    list: [],
+    loading: false,
+    error: null,
+    sortBy: locStore.get(SORT_BY_KEY_NAME) || SORT_BY_NAME,
+  },
+  archivedDirects: {
+    activeDirect: null,
+    list: [],
+    loading: false,
+    error: null,
+    sortBy: SORT_BY_NAME,
+  },
+  meetings: {
+    list: {},
+    activeMeeting: null,
+    activeMeetingKey: null,
+    loading: false,
+    error: null,
+  },
+  archivedMeetings: {
+    list: {},
+    activeMeeting: null,
+    activeMeetingKey: null,
+    loading: false,
+    error: null,
+  },
+  followUps: {
+    list: {},
+    activeFollowUp: null,
+    activeFollowUpKey: null,
+    loading: false,
+    error: null,
+  },
+  archivedFollowUp: {
+    list: {},
+    activeFollowUp: null,
+    activeFollowUpKey: null,
+    loading: false,
+    error: null,
+  },
+  auth: {
+    displayName: null,
+    uid: null,
+    email: null,
+    photoURL: null,
+    status: AUTH_ANONYMOUS,
+  },
+  header: {
+    text: '1on1 Tracker',
+  },
+  teams: {
+    list: {},
+    loading: false,
+    error: null,
+  },
+};
+
+export default initialState;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -3,13 +3,14 @@ import { browserHistory } from 'react-router';
 import { applyMiddleware, compose, createStore } from 'redux';
 import thunk from 'redux-thunk';
 
-import rootReducer from './reducers';
+import rootReducer from '../reducers/index';
+import initialState from './initialState';
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 const store = createStore(
   rootReducer,
-  {},
+  initialState,
   composeEnhancers(
     applyMiddleware(thunk, routerMiddleware(browserHistory)),
     // applyMiddleware(thunk),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6181,6 +6181,10 @@ stdout-stream@^1.4.0:
   dependencies:
     readable-stream "^2.0.1"
 
+store@^2.0.12:
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/store/-/store-2.0.12.tgz#8c534e2a0b831f72b75fc5f1119857c44ef5d593"
+
 stream-browserify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.1.tgz#66266ee5f9bdb9940a4e4514cafb43bb71e5c9db"


### PR DESCRIPTION
1. Refactoring reducers  
To make reducers pure and avoid side effects, the initial states for all reducers have moved to /src/store/initialState.js.

2. Added local storage functionalities for directs sortBy

Note: dependencies should be updated
